### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
Potential fix for [https://github.com/miguel11nines/park-it-easy-office/security/code-scanning/1](https://github.com/miguel11nines/park-it-easy-office/security/code-scanning/1)

In general, to fix this class of issue you explicitly declare a `permissions` block either at the top level of the workflow (to apply to all jobs) or inside the specific job, granting only the minimal scopes required. For a typical test workflow that only reads code and does not update repository state, `contents: read` is sufficient and recommended.

For this specific workflow in `.github/workflows/test.yml`, the simplest and least disruptive fix is to add a `permissions` block to the `test` job. Place it right under `runs-on: ubuntu-latest` (around current line 11), and set `contents: read`. This tightens the `GITHUB_TOKEN` to read-only repository contents while preserving all existing behavior, since none of the steps require write access. No additional imports or dependencies are needed; this is purely a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
